### PR TITLE
bump wm version to 0.8.1

### DIFF
--- a/way-cooler-release-i3-default.sh
+++ b/way-cooler-release-i3-default.sh
@@ -6,7 +6,7 @@ function cleanup {
 }
 
 # VERSION NUMBERS
-WM_VERSION="v0.8.0"
+WM_VERSION="v0.8.1"
 BG_VERSION="v0.3.0"
 GRAB_VERSION="v0.3.0"
 LOCK_VERSION="v0.2.1"


### PR DESCRIPTION
the 0.8.1 release fixed some failures with rust 1.30 which should be reflected by this installer.